### PR TITLE
Git Remote Helper: e2e test and fix large object hack

### DIFF
--- a/git-remote-ipfs/git-remote-ipfs.cabal
+++ b/git-remote-ipfs/git-remote-ipfs.cabal
@@ -121,6 +121,7 @@ test-suite e2e-tests
     build-depends:
         base
       , bytestring
+      , entropy
       , filepath
       , gitlib
       , gitlib-libgit2

--- a/git-remote-ipfs/test/e2e/Main.hs
+++ b/git-remote-ipfs/test/e2e/Main.hs
@@ -21,7 +21,7 @@ import           Data.Tagged (untag)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Text.Encoding (decodeUtf8)
-import           Data.Time (getZonedTime)
+import           Data.Time (ZonedTime, getZonedTime)
 import           GHC.Stack (HasCallStack)
 import           Git
 import           Git.Libgit2 (LgRepo, lgFactory)
@@ -29,6 +29,7 @@ import qualified Network.HTTP.Client as Http
 import           Network.IPFS.API (ApiV0KeyGen, ApiV0NamePublish)
 import           Servant.API
 import qualified Servant.Client as Servant
+import           System.Entropy (getEntropy)
 import           System.Environment (lookupEnv)
 import           System.Exit (ExitCode(..))
 import           System.FilePath (takeBaseName, takeDirectory, (</>))
@@ -38,99 +39,104 @@ import           System.Process.Typed
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
+type Step = String -> IO ()
+
 main :: IO ()
 main = withSystemTempDirectory "git-remote-ipfs-e2e" $ \tmp -> defaultMain $
     testGroup "E2E Tests"
-        [ testCase "Simple push, clone works" $ testPushCloneSimple tmp
-        , testCase "IPNS push, clone works"   $ testPushCloneIPNS   tmp
+        [ testCaseSteps "Push, clone: IPFS"     $ testPushCloneSimple tmp
+        , testCaseSteps "Push, clone: IPNS"     $ testPushCloneIPNS   tmp
+        , testCaseSteps "Push, clone: LOB IPFS" $ testLargeObjects    tmp
         ]
 
-testPushCloneSimple :: FilePath -> IO ()
-testPushCloneSimple root = do
-    let repoPath  = root </> "simple" </> ".git"
-    let clonePath = root </> "simple-clone" </> ".git"
+testPushCloneSimple :: FilePath -> Step -> IO ()
+testPushCloneSimple root step = runPushCloneTest PushCloneOpts
+    { pcoRepo      = root </> "simple" </> ".git"
+    , pcoClone     = root </> "simple-clone" </> ".git"
+    , pcoRemoteUrl = "ipfs://"
+    , pcoHistory   = simpleHistory
+    , pcoLog       = step
+    }
 
-    initRepo repoPath simpleHistory
-
-    url <- do
-        git_ repoPath ["remote", "add", "ipfs", "ipfs://"]
-        git_ repoPath ["push", "--quiet", "ipfs", "master"]
-        Text.strip . decodeUtf8 <$> git repoPath ["remote", "get-url", "ipfs"]
-
-    git_ clonePath ["clone", "--quiet", Text.unpack url, takeDirectory clonePath]
-
-    assertSameRepos repoPath clonePath
-
-testPushCloneIPNS :: HasCallStack => FilePath -> IO ()
-testPushCloneIPNS root = do
+testPushCloneIPNS :: FilePath -> Step -> IO ()
+testPushCloneIPNS root step = do
     let keyName = Text.pack (takeBaseName root) -- piggypack on randomness of tmp
+    step "Creating IPNS name"
     ipnsName <- Text.unpack <$> ipfs (createIpnsName keyName)
-
-    let repoPath  = root </> ipnsName </> ".git"
-    let clonePath = root </> ipnsName ++ "-clone" </> ".git"
-    let remoteUrl = "ipfs://ipns/" <> ipnsName
-
-    initRepo repoPath simpleHistory
-
-    git_ repoPath ["remote", "add", "ipns", remoteUrl]
-    git_ repoPath ["push", "--quiet", "ipns", "master"]
-
-    git_ clonePath ["clone", "--quiet", remoteUrl, takeDirectory clonePath]
-
-    assertSameRepos repoPath clonePath
+    runPushCloneTest PushCloneOpts
+        { pcoRepo      = root </> ipnsName </> ".git"
+        , pcoClone     = root </> ipnsName ++ "-clone" </> ".git"
+        , pcoRemoteUrl = "ipfs://ipns/" <> ipnsName
+        , pcoHistory   = simpleHistory
+        , pcoLog       = step
+        }
   where
     ipfs m = servantEnv >>= Servant.runClientM m >>= either throwM pure
 
-    createIpnsName :: Text -> Servant.ClientM Text
-    createIpnsName keyName = do
-        keyId <-
-            maybe (throwString "Missing key Id") pure
-                . firstOf (key "Id" . _String)
-                =<< ipfsKeyGen keyName (Just "ed25519") Nothing
-        void $
-            ipfsNamePublish ("/ipfs/" <> emptyRepo)
-                            (Just True)  -- resolve
-                            (Just "5m")  -- lifetime
-                            Nothing      -- caching
-                            (Just keyId) -- key
-        pure keyId
+testLargeObjects :: FilePath -> Step -> IO ()
+testLargeObjects root step = runPushCloneTest PushCloneOpts
+    { pcoRepo      = root </> "lobs" </> ".git"
+    , pcoClone     = root </> "lobs-clone" </> ".git"
+    , pcoRemoteUrl = "ipfs://"
+    , pcoHistory   = lobHistory
+    , pcoLog       = step
+    }
 
-    emptyRepo = "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"
+data PushCloneOpts = PushCloneOpts
+    { pcoRepo      :: FilePath
+    , pcoClone     :: FilePath
+    , pcoRemoteUrl :: String
+    , pcoHistory   :: ReaderT LgRepo IO (Commit LgRepo)
+    , pcoLog       :: Step
+    }
 
-initRepo
-    :: HasCallStack
-    => FilePath
-    -> ReaderT LgRepo IO (Maybe (Commit LgRepo))
-    -> IO ()
-initRepo path history =
-    withRepository' lgFactory (ropts path True) $
-        maybe (throwString "headless history")
-              (updateReference "refs/heads/master" . RefObj . untag . commitOid)
-            =<< history
+runPushCloneTest :: PushCloneOpts -> IO ()
+runPushCloneTest PushCloneOpts{..} = do
+    initRepo pcoLog pcoRepo pcoHistory
+    url <- pushIpfs pcoLog pcoRepo pcoRemoteUrl
+    cloneIpfs pcoLog (takeDirectory pcoClone) url
+    assertSameRepos pcoLog pcoRepo pcoClone
 
-assertSameRepos :: FilePath -> FilePath -> IO ()
-assertSameRepos src clone = do
+initRepo :: Step -> FilePath -> ReaderT LgRepo IO (Commit LgRepo) -> IO ()
+initRepo step path history = do
+    step $ "Initializing repo at " <> path
+    withRepository' lgFactory (mkROpts path True) $
+        history >>=
+            updateReference "refs/heads/master" . RefObj . untag . commitOid
+
+pushIpfs :: Step -> FilePath -> String -> IO String
+pushIpfs step repo url = do
+    step $ "Pushing master to " <> url
+    git_ repo ["remote", "add", "origin", url]
+    git_ repo ["push", "--quiet", "origin", "master"]
+    Text.unpack . Text.strip . decodeUtf8
+        <$> git repo ["remote", "get-url", "origin"]
+
+cloneIpfs :: Step -> FilePath -> String -> IO ()
+cloneIpfs step repo url = do
+    step $ "Cloning " <> url <> " to " <> repo
+    git_ repo ["clone", "--quiet", url, repo]
+
+assertSameRepos :: Step -> FilePath -> FilePath -> IO ()
+assertSameRepos step src clone = do
+    step $ "Fetching " <> src <> " to " <> clone
     git_ clone ["remote", "add", "src", src]
     git_ clone ["fetch", "--quiet", "src"]
+    step "Comparing origin/master src/master"
     void $ gitAssert "Source and cloned repository differ"
         clone ["diff", "--quiet", "origin/master", "src/master"]
 
-simpleHistory :: ReaderT LgRepo IO (Maybe (Commit LgRepo))
+simpleHistory :: ReaderT LgRepo IO (Commit LgRepo)
 simpleHistory =
-    foldlM (\parent -> fmap Just . mkCommit parent) Nothing ['a'..'z']
+    maybe (throwString "headless history") pure =<<
+        foldlM (\parent -> fmap Just . mkCommit parent) Nothing ['a'..'z']
   where
-    sig t = Signature
-        { signatureName  = "LeBoeuf"
-        , signatureEmail = "le@boe.uf"
-        , signatureWhen  = t
-        }
-
     mkCommit parent c = do
         blob <- createBlobUtf8 $ "Blob " <> Text.singleton c
         tree <-
             maybe createTree (mutateTreeOid . commitTree) parent $
                 putBlob ("blobs/" <> Bytes.singleton c) blob
-        sig' <- sig <$> liftIO getZonedTime
+        sig' <- mkSig <$> liftIO getZonedTime
         createCommit (maybeToList . fmap commitOid $ parent)
                      tree
                      sig'
@@ -138,8 +144,22 @@ simpleHistory =
                      ("Commit " <> Text.singleton c)
                      (Just "HEAD")
 
-ropts :: FilePath -> Bool -> RepositoryOptions
-ropts p autoCreate = RepositoryOptions
+lobHistory :: ReaderT LgRepo IO (Commit LgRepo)
+lobHistory = do
+    blob <- createBlob . BlobString =<< liftIO (getEntropy 4096000)
+    tree <- createTree $ putBlob "binarylargeobject" blob
+    sig' <- mkSig <$> liftIO getZonedTime
+    createCommit [] tree sig' sig' "A large bunch of bytes" (Just "HEAD")
+
+mkSig :: ZonedTime -> Signature
+mkSig t = Signature
+    { signatureName  = "LeBoeuf"
+    , signatureEmail = "le@boe.uf"
+    , signatureWhen  = t
+    }
+
+mkROpts :: FilePath -> Bool -> RepositoryOptions
+mkROpts p autoCreate = RepositoryOptions
     { repoPath       = p
     , repoWorkingDir = Nothing
     , repoIsBare     = False
@@ -180,3 +200,19 @@ servantEnv = liftA2 Servant.mkClientEnv mgr base
     base =
         Servant.parseBaseUrl
             =<< fromMaybe "http://localhost:5001" <$> lookupEnv "IPFS_API_URL"
+
+createIpnsName :: HasCallStack => Text -> Servant.ClientM Text
+createIpnsName keyName = do
+    keyId <-
+        maybe (throwString "Missing key Id") pure
+            . firstOf (key "Id" . _String)
+            =<< ipfsKeyGen keyName (Just "ed25519") Nothing
+    void $
+        ipfsNamePublish ("/ipfs/" <> emptyRepo)
+                        (Just True)  -- resolve
+                        (Just "5m")  -- lifetime
+                        Nothing      -- caching
+                        (Just keyId) -- key
+    pure keyId
+  where
+    emptyRepo = "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"


### PR DESCRIPTION
I am not sure I fully understand how this works, but apparently it does 🤷‍♂️ 

@geigerzaehler If you have an idea why [this](https://github.com/oscoin/ipfs/blob/5627befa49dc756a690455f5bc4ee2993a0859eb/git-remote-ipfs/src/Network/IPFS/Git/RemoteHelper/Client.hs#L202-L217) might exist (stolen from the Go code)? Things seem to work without it... 