### PR TITLE
Update to work with latest version of base16-bytestring

### DIFF
--- a/multibase/multibase.cabal
+++ b/multibase/multibase.cabal
@@ -49,7 +49,7 @@ library
     build-depends:
       , aeson
       , base >= 4.9 && < 5
-      , base16-bytestring
+      , base16-bytestring >= 1.0.0.0 && < 2.0.0.0
       , base32-z-bytestring
       , base58-bytestring
       , base64-bytestring

--- a/multibase/src/Data/ByteString/BaseN.hs
+++ b/multibase/src/Data/ByteString/BaseN.hs
@@ -561,15 +561,7 @@ decodeBase16 :: ByteString -> Maybe ByteString
 decodeBase16 = either (const Nothing) pure . decodeBase16Either
 
 decodeBase16Either :: ByteString -> Either String ByteString
-decodeBase16Either bs =
-    case Base16.decode bs of
-        (x, "")      -> Right x
-        (x, invalid) -> Left . mconcat $
-            [ "Decoded: "
-            , "`", unpack x, "`"
-            , " until invalid sequence: "
-            , "`", unpack invalid, "`"
-            ]
+decodeBase16Either = Base16.decode
 {-# INLINE decodeBase16Either #-}
 
 decodeBase64 :: ByteString -> Maybe ByteString


### PR DESCRIPTION
Previously would not compile against latest version.